### PR TITLE
Fix Connectedfactory.json encoding to conform to UTF-8

### DIFF
--- a/Deployment/Connectedfactory.json
+++ b/Deployment/Connectedfactory.json
@@ -126,7 +126,7 @@
       "type": "string",
       "defaultValue": "P30D",
       "metadata": {
-        "description": "The minimum timespan the environment’s events will be available for query. The value must be specified in the ISO 8601 format, e.g. \"P30D\" for a retention policy of 30 days."
+        "description": "The minimum timespan the environmentâ€™s events will be available for query. The value must be specified in the ISO 8601 format, e.g. \"P30D\" for a retention policy of 30 days."
       }
     },
     "rdxDnsName": {


### PR DESCRIPTION
When attempting to use `Connectedfactory.json`, I was getting the following error:

```
Deployment failed. 'utf-8' codec can't decode byte 0x92 in position 3599: invalid start byte
```

I fixed the encoding using Notepad++.