### PR TITLE
Allow connections to server with sha1 signed certificate

### DIFF
--- a/WebApp/Application.Config.xml
+++ b/WebApp/Application.Config.xml
@@ -45,6 +45,15 @@
       <StoreType>Directory</StoreType>
       <StorePath>%LocalFolder%/OPC Foundation/CertificateStores/RejectedCertificates</StorePath>
     </RejectedCertificateStore>
+
+    <!-- WARNING: The following setting (to automatically accept untrusted certificates) should be used
+    for easy debugging purposes ONLY and turned off for production deployments! -->
+    <AutoAcceptUntrustedCertificates>false</AutoAcceptUntrustedCertificates>
+
+    <!-- WARNING: SHA1 signed certficates are by default rejected and should be phased out.
+    The setting below to allow them is only required for UACTT (1.02.336.244) which uses SHA-1 signed certs. -->
+    <RejectSHA1SignedCertificates>false</RejectSHA1SignedCertificates>
+    <MinimumCertificateKeySize>1024</MinimumCertificateKeySize>
   
   </SecurityConfiguration>
  


### PR DESCRIPTION
For connections to OPC UA servers,
we need to allow sha1 signed certificates.

The order in the xml file is important!

Signed-off-by: Juergen Kosel <juergen.kosel@softing.com>