### PR TITLE
Add gateway sample scripts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -40,7 +40,8 @@
 *.svg       text
 
 *.cshtml    text
-
+# For shell scripts <cr><lf> line endings are dangerous
+*.sh		text eol=lf
 
 ###############################################################################
 # behavior for image files

--- a/WebApp/Views/AddGateway/startGatewayComponents.sh
+++ b/WebApp/Views/AddGateway/startGatewayComponents.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+# Sample shell script to start the requiered components on a gateway device.
+# This script assumes, that it runs either on a Linux system
+# or on a Windows system in cygwin or mingw environment (git for Windows installs a mingw environment)
+
+# Please set the following variabels to your local requierements:
+
+# Define your IoT-hub connect string
+#(within the '' to prevent the shell from doing bad things with the special characters like the = ):
+_HUB_CS='replace with your connect string'
+
+# Set the docker shared root variable, so that the docker containers could access the files stored on your real drive:
+# In the example below, it is assumed, that on Linux the directory /shared is shared with the docker containers.
+# And for Windows the driver D: is a shared driver for docker, and it contains the directory docker.
+
+case `uname` in
+Linux)	# Running on Linux
+		DOCKER_SHARED_ROOT=/shared
+		;;
+*)		# Running on Windows in mingw environment
+		DOCKER_SHARED_ROOT=//D/docker
+		;;
+esac
+
+# Initialy run the publisher to initialize itself and register itself at the IoT-hub:
+docker run -it --rm -h publisher -v ${DOCKER_SHARED_ROOT}:/build/out/CertificateStores -v ${DOCKER_SHARED_ROOT}:/root/.dotnet/corefx/cryptography/x509stores microsoft/iot-edge-opc-publisher:2.0.3 publisher "$_HUB_CS"
+# Run the publisher permanently, so that it is accessible by port 62222 from the "outside"
+docker run -it --rm -h publisher --expose 62222 -p 62222:62222 -v ${DOCKER_SHARED_ROOT}:/build/out/Logs -v ${DOCKER_SHARED_ROOT}:/build/out/CertificateStores -v ${DOCKER_SHARED_ROOT}:/shared -v ${DOCKER_SHARED_ROOT}:/root/.dotnet/corefx/cryptography/x509stores -e _GW_PNFP="/shared/publishednodes.JSON" microsoft/iot-edge-opc-publisher:2.0.3 publisher &
+
+# Initially run the publisher to register itself at the IoT-hub:
+docker run -it --rm -v ${DOCKER_SHARED_ROOT}:/mapped microsoft/iot-edge-opc-proxy:1.0.3 -i -c "$_HUB_CS" -D /mapped/cs.db
+# Run the proxy permanently, so that the connected factory could connect to OPC UA servers through the proxy tunnel:
+docker run -it --rm -v ${DOCKER_SHARED_ROOT}:/mapped microsoft/iot-edge-opc-proxy:1.0.3 -D /mapped/cs.db &

--- a/WebApp/Views/AddGateway/startGatewayComponents.sh
+++ b/WebApp/Views/AddGateway/startGatewayComponents.sh
@@ -11,6 +11,10 @@ _HUB_CS='replace with your connect string'
 # Set the docker shared root variable, so that the docker containers could access the files stored on your real drive:
 # In the example below, it is assumed, that on Linux the directory /shared is shared with the docker containers.
 DOCKER_SHARED_ROOT=/shared
+# Insert your hostname and IP address to these variables:
+set MYHOSTNAME=`hostname`
+set MYIP=192.168.237.10
+# Initially run the publisher to register itself at the IoT-hub:
 
 # Initialy run the publisher to initialize itself and register itself at the IoT-hub:
 docker run -it --rm -h publisher -v ${DOCKER_SHARED_ROOT}:/build/out/CertificateStores -v ${DOCKER_SHARED_ROOT}:/root/.dotnet/corefx/cryptography/x509stores microsoft/iot-edge-opc-publisher:2.0.3 publisher "$_HUB_CS"
@@ -20,4 +24,4 @@ docker run -it --rm -h publisher --expose 62222 -p 62222:62222 -v ${DOCKER_SHARE
 # Initially run the publisher to register itself at the IoT-hub:
 docker run -it --rm -v ${DOCKER_SHARED_ROOT}:/mapped microsoft/iot-edge-opc-proxy:1.0.3 -i -c "$_HUB_CS" -D /mapped/cs.db
 # Run the proxy permanently, so that the connected factory could connect to OPC UA servers through the proxy tunnel:
-docker run -it --rm -v ${DOCKER_SHARED_ROOT}:/mapped microsoft/iot-edge-opc-proxy:1.0.3 -D /mapped/cs.db &
+docker run -it --rm -v ${DOCKER_SHARED_ROOT}:/mapped --add-host "$MYHOSTNAME publisher":$MYIP microsoft/iot-edge-opc-proxy:1.0.3 -D /mapped/cs.db &

--- a/WebApp/Views/AddGateway/startGatewayComponents.sh
+++ b/WebApp/Views/AddGateway/startGatewayComponents.sh
@@ -16,10 +16,8 @@ set MYHOSTNAME=`hostname`
 set MYIP=192.168.237.10
 # Initially run the publisher to register itself at the IoT-hub:
 
-# Initialy run the publisher to initialize itself and register itself at the IoT-hub:
-docker run -it --rm -h publisher -v ${DOCKER_SHARED_ROOT}:/build/out/CertificateStores -v ${DOCKER_SHARED_ROOT}:/root/.dotnet/corefx/cryptography/x509stores microsoft/iot-edge-opc-publisher:2.0.3 publisher "$_HUB_CS"
 # Run the publisher permanently, so that it is accessible by port 62222 from the "outside"
-docker run -it --rm -h publisher --expose 62222 -p 62222:62222 -v ${DOCKER_SHARED_ROOT}:/build/out/Logs -v ${DOCKER_SHARED_ROOT}:/build/out/CertificateStores -v ${DOCKER_SHARED_ROOT}:/shared -v ${DOCKER_SHARED_ROOT}:/root/.dotnet/corefx/cryptography/x509stores -e _GW_PNFP="/shared/publishednodes.JSON" microsoft/iot-edge-opc-publisher:2.0.3 publisher &
+docker run -it --rm -h publisher --expose 62222 -p 62222:62222 -v ${DOCKER_SHARED_ROOT}:/build/out/Logs -v ${DOCKER_SHARED_ROOT}:/build/out/CertificateStores -v ${DOCKER_SHARED_ROOT}:/shared -v ${DOCKER_SHARED_ROOT}:/root/.dotnet/corefx/cryptography/x509stores -e _GW_PNFP="/shared/publishednodes.JSON" microsoft/iot-edge-opc-publisher:2.0.3 publisher "$_HUB_CS" &
 
 # Initially run the publisher to register itself at the IoT-hub:
 docker run -it --rm -v ${DOCKER_SHARED_ROOT}:/mapped microsoft/iot-edge-opc-proxy:1.0.3 -i -c "$_HUB_CS" -D /mapped/cs.db

--- a/WebApp/Views/AddGateway/startGatewayComponents.sh
+++ b/WebApp/Views/AddGateway/startGatewayComponents.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 # Sample shell script to start the requiered components on a gateway device.
-# This script assumes, that it runs either on a Linux system
-# or on a Windows system in cygwin or mingw environment (git for Windows installs a mingw environment)
+# This script assumes, that it runs on a Linux system
 
 # Please set the following variabels to your local requierements:
 
@@ -11,16 +10,7 @@ _HUB_CS='replace with your connect string'
 
 # Set the docker shared root variable, so that the docker containers could access the files stored on your real drive:
 # In the example below, it is assumed, that on Linux the directory /shared is shared with the docker containers.
-# And for Windows the driver D: is a shared driver for docker, and it contains the directory docker.
-
-case `uname` in
-Linux)	# Running on Linux
-		DOCKER_SHARED_ROOT=/shared
-		;;
-*)		# Running on Windows in mingw environment
-		DOCKER_SHARED_ROOT=//D/docker
-		;;
-esac
+DOCKER_SHARED_ROOT=/shared
 
 # Initialy run the publisher to initialize itself and register itself at the IoT-hub:
 docker run -it --rm -h publisher -v ${DOCKER_SHARED_ROOT}:/build/out/CertificateStores -v ${DOCKER_SHARED_ROOT}:/root/.dotnet/corefx/cryptography/x509stores microsoft/iot-edge-opc-publisher:2.0.3 publisher "$_HUB_CS"

--- a/WebApp/Views/AddGateway/startProxy.bat
+++ b/WebApp/Views/AddGateway/startProxy.bat
@@ -7,12 +7,19 @@
 set _HUB_CS='replace with your connect string'
 ::#Set the docker shared root variable, so that the docker containers could access the files stored on your real drive:
 ::# In the example below, it is assumed, that drive D: is a shared driver for docker, and it contains the directory docker.
-set DOCKER_SHARED_ROOT=//D/docker
+set DOCKER_SHARED_ROOT=//C/docker
 
-::# Insert your hostname and IP address to these variables:
-set MYHOSTNAME=DESKTOP-0EBERG1.example.net
-set MYIP=192.168.237.10
+::# Insert the hostname with domain of the publisher and IP address to these variables:
+set MYHOSTNAME=publisher.example.com
+set MYIP=10.123.45.26
+
+docker network create -d bridge iot_edge
 ::# Initially run the publisher to register itself at the IoT-hub:
-docker run -it --rm --name proxy -v %DOCKER_SHARED_ROOT%:/mapped microsoft/iot-edge-opc-proxy:1.0.3 -i -c "%_HUB_CS%" -D /mapped/cs.db
-::# Run the proxy permanently, so that the connected factory could connect to OPC UA servers through the proxy tunnel:
-docker run -it --rm --name proxy -v %DOCKER_SHARED_ROOT%:/mapped --add-host "%MYHOSTNAME%":%MYIP% microsoft/iot-edge-opc-proxy:1.0.3 -D /mapped/cs.db
+
+:foreverloop
+
+	docker run -it --rm --name proxy --network iot_edge -v %DOCKER_SHARED_ROOT%:/mapped microsoft/iot-gateway-opc-ua-proxy:1.0.2 -i -c "%_HUB_CS%" -D /mapped/cs.db
+	::# Run the proxy permanently, so that the connected factory could connect to OPC UA servers through the proxy tunnel:
+	docker run -it --rm --name proxy --network iot_edge -v %DOCKER_SHARED_ROOT%:/mapped --add-host "%MYHOSTNAME%":%MYIP% microsoft/iot-gateway-opc-ua-proxy:1.0.2 -D /mapped/cs.db
+
+goto foreverloop

--- a/WebApp/Views/AddGateway/startProxy.bat
+++ b/WebApp/Views/AddGateway/startProxy.bat
@@ -1,0 +1,15 @@
+::# Sample shell script to start the publisher components on a gateway device.
+::# This script assumes, that it runs on a Linux system
+
+::# Please set the following variabels to your local requierements:
+
+::# Define your IoT-hub connect string
+set _HUB_CS='replace with your connect string'
+::#Set the docker shared root variable, so that the docker containers could access the files stored on your real drive:
+::# In the example below, it is assumed, that drive D: is a shared driver for docker, and it contains the directory docker.
+set DOCKER_SHARED_ROOT=//D/docker
+
+::# Initially run the publisher to register itself at the IoT-hub:
+docker run -it --rm -v %DOCKER_SHARED_ROOT%:/mapped microsoft/iot-edge-opc-proxy:1.0.3 -i -c "%_HUB_CS%" -D /mapped/cs.db
+::# Run the proxy permanently, so that the connected factory could connect to OPC UA servers through the proxy tunnel:
+docker run -it --rm -v %DOCKER_SHARED_ROOT%:/mapped microsoft/iot-edge-opc-proxy:1.0.3 -D /mapped/cs.db

--- a/WebApp/Views/AddGateway/startProxy.bat
+++ b/WebApp/Views/AddGateway/startProxy.bat
@@ -14,8 +14,9 @@ set MYHOSTNAME=publisher.example.com
 set MYIP=10.123.45.26
 
 docker network create -d bridge iot_edge
+::# Stop any preiviously started proxy instance
+docker container stop proxy
 ::# Initially run the publisher to register itself at the IoT-hub:
-
 docker run -it --rm --name proxy --network iot_edge -v %DOCKER_SHARED_ROOT%:/mapped microsoft/iot-gateway-opc-ua-proxy:1.0.2 -i -c "%_HUB_CS%" -D /mapped/cs.db
 ::# Run the proxy permanently, so that the connected factory could connect to OPC UA servers through the proxy tunnel:
 ::# Workaround for https://github.com/Azure/iot-edge-opc-proxy/issues/79 :

--- a/WebApp/Views/AddGateway/startProxy.bat
+++ b/WebApp/Views/AddGateway/startProxy.bat
@@ -9,7 +9,10 @@ set _HUB_CS='replace with your connect string'
 ::# In the example below, it is assumed, that drive D: is a shared driver for docker, and it contains the directory docker.
 set DOCKER_SHARED_ROOT=//D/docker
 
+::# Insert your hostname and IP address to these variables:
+set MYHOSTNAME=DESKTOP-0EBERG1
+set MYIP=192.168.237.10
 ::# Initially run the publisher to register itself at the IoT-hub:
 docker run -it --rm -v %DOCKER_SHARED_ROOT%:/mapped microsoft/iot-edge-opc-proxy:1.0.3 -i -c "%_HUB_CS%" -D /mapped/cs.db
 ::# Run the proxy permanently, so that the connected factory could connect to OPC UA servers through the proxy tunnel:
-docker run -it --rm -v %DOCKER_SHARED_ROOT%:/mapped microsoft/iot-edge-opc-proxy:1.0.3 -D /mapped/cs.db
+docker run -it --rm -v %DOCKER_SHARED_ROOT%:/mapped --add-host "%MYHOSTNAME% publisher":%MYIP% microsoft/iot-edge-opc-proxy:1.0.3 -D /mapped/cs.db

--- a/WebApp/Views/AddGateway/startProxy.bat
+++ b/WebApp/Views/AddGateway/startProxy.bat
@@ -13,6 +13,6 @@ set DOCKER_SHARED_ROOT=//D/docker
 set MYHOSTNAME=DESKTOP-0EBERG1.example.net
 set MYIP=192.168.237.10
 ::# Initially run the publisher to register itself at the IoT-hub:
-docker run -it --rm -v %DOCKER_SHARED_ROOT%:/mapped microsoft/iot-edge-opc-proxy:1.0.3 -i -c "%_HUB_CS%" -D /mapped/cs.db
+docker run -it --rm --name proxy -v %DOCKER_SHARED_ROOT%:/mapped microsoft/iot-edge-opc-proxy:1.0.3 -i -c "%_HUB_CS%" -D /mapped/cs.db
 ::# Run the proxy permanently, so that the connected factory could connect to OPC UA servers through the proxy tunnel:
-docker run -it --rm -v %DOCKER_SHARED_ROOT%:/mapped --add-host "%MYHOSTNAME%":%MYIP% microsoft/iot-edge-opc-proxy:1.0.3 -D /mapped/cs.db
+docker run -it --rm --name proxy -v %DOCKER_SHARED_ROOT%:/mapped --add-host "%MYHOSTNAME%":%MYIP% microsoft/iot-edge-opc-proxy:1.0.3 -D /mapped/cs.db

--- a/WebApp/Views/AddGateway/startProxy.bat
+++ b/WebApp/Views/AddGateway/startProxy.bat
@@ -16,10 +16,13 @@ set MYIP=10.123.45.26
 docker network create -d bridge iot_edge
 ::# Initially run the publisher to register itself at the IoT-hub:
 
+docker run -it --rm --name proxy --network iot_edge -v %DOCKER_SHARED_ROOT%:/mapped microsoft/iot-gateway-opc-ua-proxy:1.0.2 -i -c "%_HUB_CS%" -D /mapped/cs.db
+::# Run the proxy permanently, so that the connected factory could connect to OPC UA servers through the proxy tunnel:
+::# Workaround for https://github.com/Azure/iot-edge-opc-proxy/issues/79 :
+::# Use docker option --restart always
+docker run -it --restart always --name proxy --network iot_edge -v %DOCKER_SHARED_ROOT%:/mapped --add-host "%MYHOSTNAME%":%MYIP% microsoft/iot-gateway-opc-ua-proxy:1.0.2 -D /mapped/cs.db
+
 :foreverloop
-
-	docker run -it --rm --name proxy --network iot_edge -v %DOCKER_SHARED_ROOT%:/mapped microsoft/iot-gateway-opc-ua-proxy:1.0.2 -i -c "%_HUB_CS%" -D /mapped/cs.db
-	::# Run the proxy permanently, so that the connected factory could connect to OPC UA servers through the proxy tunnel:
-	docker run -it --rm --name proxy --network iot_edge -v %DOCKER_SHARED_ROOT%:/mapped --add-host "%MYHOSTNAME%":%MYIP% microsoft/iot-gateway-opc-ua-proxy:1.0.2 -D /mapped/cs.db
-
+	::# Get output of the restarted docker container proxy:
+	docker container attach proxy
 goto foreverloop

--- a/WebApp/Views/AddGateway/startProxy.bat
+++ b/WebApp/Views/AddGateway/startProxy.bat
@@ -10,9 +10,9 @@ set _HUB_CS='replace with your connect string'
 set DOCKER_SHARED_ROOT=//D/docker
 
 ::# Insert your hostname and IP address to these variables:
-set MYHOSTNAME=DESKTOP-0EBERG1
+set MYHOSTNAME=DESKTOP-0EBERG1.example.net
 set MYIP=192.168.237.10
 ::# Initially run the publisher to register itself at the IoT-hub:
 docker run -it --rm -v %DOCKER_SHARED_ROOT%:/mapped microsoft/iot-edge-opc-proxy:1.0.3 -i -c "%_HUB_CS%" -D /mapped/cs.db
 ::# Run the proxy permanently, so that the connected factory could connect to OPC UA servers through the proxy tunnel:
-docker run -it --rm -v %DOCKER_SHARED_ROOT%:/mapped --add-host "%MYHOSTNAME% publisher":%MYIP% microsoft/iot-edge-opc-proxy:1.0.3 -D /mapped/cs.db
+docker run -it --rm -v %DOCKER_SHARED_ROOT%:/mapped --add-host "%MYHOSTNAME%":%MYIP% microsoft/iot-edge-opc-proxy:1.0.3 -D /mapped/cs.db

--- a/WebApp/Views/AddGateway/startPublisher.bat
+++ b/WebApp/Views/AddGateway/startPublisher.bat
@@ -7,7 +7,8 @@
 set _HUB_CS='replace with your connect string'
 ::#Set the docker shared root variable, so that the docker containers could access the files stored on your real drive:
 ::# In the example below, it is assumed, that drive D: is a shared driver for docker, and it contains the directory docker.
-set DOCKER_SHARED_ROOT=//D/docker
+set DOCKER_SHARED_ROOT=//C/docker
 
+docker network create -d bridge iot_edge
 ::# Run the publisher permanently, so that it is accessible by port 62222 from the "outside"
-docker run -it --rm -h publisher --name publisher -p 62222:62222 -v %DOCKER_SHARED_ROOT%:/build/out/Logs -v %DOCKER_SHARED_ROOT%:/build/out/CertificateStores -v %DOCKER_SHARED_ROOT%:/shared -v %DOCKER_SHARED_ROOT%:/root/.dotnet/corefx/cryptography/x509stores -e _GW_PNFP="/shared/publishednodes.JSON" microsoft/iot-edge-opc-publisher:2.0.3 publisher.example.net "%_HUB_CS%"
+docker run -it --rm --network iot_edge -h publisher --name publisher -p 62222:62222 -v %DOCKER_SHARED_ROOT%:/docker -v myx509certstore:/root/.dotnet/corefx/cryptography/x509stores microsoft/iot-edge-opc-publisher:2.1.1 publisher.example.com "%_HUB_CS%" --lf ./publisher.log.txt --pf /docker/publishednodes.json --ih Http1 --as true --tm true --si 0 --ms 0 --sd "example.com" --trustedcertstorepath=/docker/CertificateStores/trusted --rejectedcertstorepath=/docker/CertificateStores/rejected

--- a/WebApp/Views/AddGateway/startPublisher.bat
+++ b/WebApp/Views/AddGateway/startPublisher.bat
@@ -1,0 +1,15 @@
+::# Sample shell script to start the publisher components on a gateway device.
+::# This script assumes, that it runs on a Linux system
+
+::# Please set the following variabels to your local requierements:
+
+::# Define your IoT-hub connect string
+set _HUB_CS='replace with your connect string'
+::#Set the docker shared root variable, so that the docker containers could access the files stored on your real drive:
+::# In the example below, it is assumed, that drive D: is a shared driver for docker, and it contains the directory docker.
+set DOCKER_SHARED_ROOT=//D/docker
+
+::# Initialy run the publisher to initialize itself and register itself at the IoT-hub:
+docker run -it --rm -h publisher -v %DOCKER_SHARED_ROOT%:/build/out/CertificateStores -v %DOCKER_SHARED_ROOT%:/root/.dotnet/corefx/cryptography/x509stores microsoft/iot-edge-opc-publisher:2.0.3 publisher "%_HUB_CS%"
+::# Run the publisher permanently, so that it is accessible by port 62222 from the "outside"
+docker run -it --rm -h publisher --expose 62222 -p 62222:62222 -v %DOCKER_SHARED_ROOT%:/build/out/Logs -v %DOCKER_SHARED_ROOT%:/build/out/CertificateStores -v %DOCKER_SHARED_ROOT%:/shared -v %DOCKER_SHARED_ROOT%:/root/.dotnet/corefx/cryptography/x509stores -e _GW_PNFP="/shared/publishednodes.JSON" microsoft/iot-edge-opc-publisher:2.0.3 publisher

--- a/WebApp/Views/AddGateway/startPublisher.bat
+++ b/WebApp/Views/AddGateway/startPublisher.bat
@@ -11,4 +11,4 @@ set DOCKER_SHARED_ROOT=//C/docker
 
 docker network create -d bridge iot_edge
 ::# Run the publisher permanently, so that it is accessible by port 62222 from the "outside"
-docker run -it --rm --network iot_edge -h publisher --name publisher -p 62222:62222 -v %DOCKER_SHARED_ROOT%:/docker -v myx509certstore:/root/.dotnet/corefx/cryptography/x509stores microsoft/iot-edge-opc-publisher:2.1.1 publisher.example.com "%_HUB_CS%" --lf ./publisher.log.txt --pf /docker/publishednodes.json --ih Http1 --as true --tm true --si 0 --ms 0 --sd "example.com" --trustedcertstorepath=/docker/CertificateStores/trusted --rejectedcertstorepath=/docker/CertificateStores/rejected
+docker run -it --rm --network iot_edge -h publisher --name publisher -p 62222:62222 -v %DOCKER_SHARED_ROOT%:/docker -v myx509certstore:/root/.dotnet/corefx/cryptography/x509stores microsoft/iot-edge-opc-publisher:2.1.2 publisher.example.com "%_HUB_CS%" --lf ./publisher.log.txt --ns true --pf /docker/publishednodes.json --ih Http1 --as true --tm true --si 0 --ms 0 --sd "example.com" --trustedcertstorepath=/docker/CertificateStores/trusted --rejectedcertstorepath=/docker/CertificateStores/rejected

--- a/WebApp/Views/AddGateway/startPublisher.bat
+++ b/WebApp/Views/AddGateway/startPublisher.bat
@@ -10,4 +10,4 @@ set _HUB_CS='replace with your connect string'
 set DOCKER_SHARED_ROOT=//D/docker
 
 ::# Run the publisher permanently, so that it is accessible by port 62222 from the "outside"
-docker run -it --rm -h publisher --expose 62222 -p 62222:62222 -v %DOCKER_SHARED_ROOT%:/build/out/Logs -v %DOCKER_SHARED_ROOT%:/build/out/CertificateStores -v %DOCKER_SHARED_ROOT%:/shared -v %DOCKER_SHARED_ROOT%:/root/.dotnet/corefx/cryptography/x509stores -e _GW_PNFP="/shared/publishednodes.JSON" microsoft/iot-edge-opc-publisher:2.0.3 publisher "%_HUB_CS%"
+docker run -it --rm -h publisher --name publisher -p 62222:62222 -v %DOCKER_SHARED_ROOT%:/build/out/Logs -v %DOCKER_SHARED_ROOT%:/build/out/CertificateStores -v %DOCKER_SHARED_ROOT%:/shared -v %DOCKER_SHARED_ROOT%:/root/.dotnet/corefx/cryptography/x509stores -e _GW_PNFP="/shared/publishednodes.JSON" microsoft/iot-edge-opc-publisher:2.0.3 publisher.example.net "%_HUB_CS%"

--- a/WebApp/Views/AddGateway/startPublisher.bat
+++ b/WebApp/Views/AddGateway/startPublisher.bat
@@ -9,7 +9,5 @@ set _HUB_CS='replace with your connect string'
 ::# In the example below, it is assumed, that drive D: is a shared driver for docker, and it contains the directory docker.
 set DOCKER_SHARED_ROOT=//D/docker
 
-::# Initialy run the publisher to initialize itself and register itself at the IoT-hub:
-docker run -it --rm -h publisher -v %DOCKER_SHARED_ROOT%:/build/out/CertificateStores -v %DOCKER_SHARED_ROOT%:/root/.dotnet/corefx/cryptography/x509stores microsoft/iot-edge-opc-publisher:2.0.3 publisher "%_HUB_CS%"
 ::# Run the publisher permanently, so that it is accessible by port 62222 from the "outside"
-docker run -it --rm -h publisher --expose 62222 -p 62222:62222 -v %DOCKER_SHARED_ROOT%:/build/out/Logs -v %DOCKER_SHARED_ROOT%:/build/out/CertificateStores -v %DOCKER_SHARED_ROOT%:/shared -v %DOCKER_SHARED_ROOT%:/root/.dotnet/corefx/cryptography/x509stores -e _GW_PNFP="/shared/publishednodes.JSON" microsoft/iot-edge-opc-publisher:2.0.3 publisher
+docker run -it --rm -h publisher --expose 62222 -p 62222:62222 -v %DOCKER_SHARED_ROOT%:/build/out/Logs -v %DOCKER_SHARED_ROOT%:/build/out/CertificateStores -v %DOCKER_SHARED_ROOT%:/shared -v %DOCKER_SHARED_ROOT%:/root/.dotnet/corefx/cryptography/x509stores -e _GW_PNFP="/shared/publishednodes.JSON" microsoft/iot-edge-opc-publisher:2.0.3 publisher "%_HUB_CS%"


### PR DESCRIPTION
As suggested in issue #22 this pull request provides sample scripts
to start the proxy and publisher in docker containers on Linux or Windows gateways.
