### PR TITLE
Define redirect uri dynamically

### DIFF
--- a/WebApp/App_Start/Startup.Auth.cs
+++ b/WebApp/App_Start/Startup.Auth.cs
@@ -52,6 +52,7 @@ namespace Microsoft.Azure.IoTSuite.Connectedfactory.WebApp
                         RedirectToIdentityProvider = context =>
                         {
                             Trace.TraceInformation("ConfigureAuth: RedirectToIdentityProvider - ClientId: {0}", context.ProtocolMessage.ClientId);
+                            context.ProtocolMessage.RedirectUri = context.Request.Scheme + "://" + context.Request.Host.ToString();
                             return Task.FromResult(0);
                         },
                         SecurityTokenReceived = context =>


### PR DESCRIPTION
In some scenarios, the Active Directory Application can have multiple
allowed redirect uris. This could be if the same site is accessible
via multiple domains. Another scenario is where during development one
might want to reuse the same authentication settings, but allow running
the WebApp in a localhost environment.

With this change, the redirect uri used will be the one the site was
accessed originally, which means that user gets redirected back to
where the flow started from (rather than just the most recent uri in
the Active Directory Appliation configuration).