### PR TITLE
Use .NET container image from MCR

### DIFF
--- a/Simulation/Factory/Dockerfile
+++ b/Simulation/Factory/Dockerfile
@@ -1,4 +1,4 @@
-FROM microsoft/dotnet:2.1-runtime
+FROM mcr.microsoft.com/dotnet/runtime:2.1
 
 COPY . /app/buildOutput
 


### PR DESCRIPTION
Connected Factory simulation does not work because .NET 2.1 Docker container images are no longer be available on Docker Hub. 

Pull .NET container image from Microsoft Container Registry to fix the issue.

See this post:
https://devblogs.microsoft.com/dotnet/net-core-2-1-container-images-will-be-deleted-from-docker-hub/